### PR TITLE
Fix PHP warning when HTTP_ACCEPT_LANGUAGE header is missin

### DIFF
--- a/action.php
+++ b/action.php
@@ -151,7 +151,7 @@ class action_plugin_botmon extends DokuWiki_Action_Plugin {
 			$_SERVER['HTTP_USER_AGENT'] ?? '', /* User agent */
 			$_SERVER['HTTP_REFERER'] ?? '', /* HTTP Referrer */
 			substr($conf['lang'],0,2), /* page language */
-			implode(',', array_unique(array_map( function($it) { return substr(trim($it),0,2); }, explode(',',trim($_SERVER['HTTP_ACCEPT_LANGUAGE'], " \t;,*"))))), /* accepted client languages */
+			implode(',', array_unique(array_map( function($it) { return substr(trim($it),0,2); }, explode(',',trim($_SERVER['HTTP_ACCEPT_LANGUAGE'] ?? '', " \t;,*"))))), /* accepted client languages */
 			$this->getCountryCode(), /* GeoIP country code */
 			$this->showCaptcha, /* show captcha? */
 			$_SERVER['REQUEST_METHOD'] ?? '' /* request method */


### PR DESCRIPTION
This change makes the handling of the HTTP_ACCEPT_LANGUAGE server variable more robust by safely accessing it when present and falling back to an empty value otherwise. It prevents PHP 8+ warnings (Undefined array key) triggered by requests that do not include the Accept-Language HTTP header (e.g. bots, monitoring tools, or CLI requests), while preserving the existing language parsing logic.